### PR TITLE
Feat: Update sport details by service provider

### DIFF
--- a/src/main/java/com/bookmysport/service_provider_place_reg/Controllers/SPMainController.java
+++ b/src/main/java/com/bookmysport/service_provider_place_reg/Controllers/SPMainController.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,6 +19,7 @@ import com.bookmysport.service_provider_place_reg.Models.ResponseMessage;
 import com.bookmysport.service_provider_place_reg.Models.SportsDB;
 import com.bookmysport.service_provider_place_reg.Services.FetchSportsImages;
 import com.bookmysport.service_provider_place_reg.Services.ImageUploadService;
+import com.bookmysport.service_provider_place_reg.Services.UpdateSportDetials;
 import com.bookmysport.service_provider_place_reg.Services.UploadSportsService;
 
 @RestController
@@ -35,6 +37,9 @@ public class SPMainController {
 
     @Autowired
     private FetchSportsImages fetchSportsImages;
+
+    @Autowired
+    private UpdateSportDetials updateSportDetials;
 
     @GetMapping("getdetails")
     public ResponseEntity<ResponseMessage> getSPDetaills(@RequestHeader String token, @RequestHeader String role) {
@@ -67,5 +72,11 @@ public class SPMainController {
     public ResponseEntity<Object> getSportBySportIdAndSpId(@RequestHeader String spId,@RequestHeader String sportId)
     {
         return fetchSportsImages.fetchSportBySportIdAndSpIdService(spId ,sportId);
+    }
+
+    @PutMapping("updatesportdetails")
+    public ResponseEntity<ResponseMessage> updateSportDetails(@RequestBody SportsDB latestsportDetails)
+    {
+        return updateSportDetials.updateSportDetailsService(latestsportDetails);
     }
 }

--- a/src/main/java/com/bookmysport/service_provider_place_reg/Services/UpdateSportDetials.java
+++ b/src/main/java/com/bookmysport/service_provider_place_reg/Services/UpdateSportDetials.java
@@ -1,0 +1,49 @@
+package com.bookmysport.service_provider_place_reg.Services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import com.bookmysport.service_provider_place_reg.Models.ResponseMessage;
+import com.bookmysport.service_provider_place_reg.Models.SportsDB;
+import com.bookmysport.service_provider_place_reg.Repositories.SportsDBRepo;
+
+@Service
+public class UpdateSportDetials {
+
+    @Autowired
+    private SportsDBRepo sportsDBRepo;
+
+    @Autowired
+    private ResponseMessage responseMessage;
+
+    public ResponseEntity<ResponseMessage> updateSportDetailsService(SportsDB latestsportDetails) {
+        try {
+            SportsDB sportToBeUpdated = sportsDBRepo.findBySpIdAndSportId(latestsportDetails.getSpId(),
+                    latestsportDetails.getSportId());
+
+            if (sportToBeUpdated == null) {
+                responseMessage.setSuccess(false);
+                responseMessage.setMessage("Sport with sportId: " + latestsportDetails.getSportId() + " and with spId: "
+                        + latestsportDetails.getSpId() + " doesn't exist.");
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(responseMessage);
+            } else {
+                sportToBeUpdated.setSportName(latestsportDetails.getSportName());
+                sportToBeUpdated.setPricePerHour(latestsportDetails.getPricePerHour());
+                sportToBeUpdated.setNumberOfCourts(latestsportDetails.getNumberOfCourts());
+                sportsDBRepo.save(sportToBeUpdated);
+
+                responseMessage.setSuccess(true);
+                responseMessage.setMessage("Sport details updated successfully");
+                return ResponseEntity.status(HttpStatus.OK).body(responseMessage);
+            }
+        } catch (Exception e) {
+            responseMessage.setSuccess(false);
+            responseMessage
+                    .setMessage("Internal Server Error in method updateSportDetailsService. Reason: " + e.getMessage());
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(responseMessage);
+        }
+
+    }
+}


### PR DESCRIPTION
Issue: #3 

In this pull request I have added the feature where a **service provider can edit the sport details** as mentioned in the issue.

### Updates can be done by service provider:

1. Sport name
2. Price per hour of particular sport
3. Number of courts ( Availability of courts )

### Details given by service provider:
1. Sport ID
2. Service provider ID
3. Sport name
4. Price per hour of the sport
5. Number of courts for the particular sport

### Image from Postman:

![image](https://github.com/BookMySport-com-Platform/Service-Provider-Place-Registration/assets/131521505/bd6c5d5a-ffcd-4b52-8cfd-ab8abd058c98)
