### PR TITLE
Change the key of the images

### DIFF
--- a/src/main/java/com/bookmysport/service_provider_place_reg/Services/S3PutObjectService.java
+++ b/src/main/java/com/bookmysport/service_provider_place_reg/Services/S3PutObjectService.java
@@ -79,10 +79,11 @@ public class S3PutObjectService {
     public ResponseEntity<ResponseMessage> putObjectService(String spId, String key, MultipartFile image) {
         S3Client client = S3Data.s3Client;
 
+        String folderName = System.getenv("FOLDER_FOR_SERVICE_PROVIDER_IMAGES");
         try {
             PutObjectRequest putOb = PutObjectRequest.builder()
                     .bucket(S3Data.bucketName)
-                    .key(spId + '/' + key)
+                    .key(folderName + '/' + spId + '/' + key)
                     .contentType(image.getContentType())
                     .build();
 
@@ -93,19 +94,21 @@ public class S3PutObjectService {
             if (response.eTag().isEmpty()) {
                 responseMessage.setSuccess(false);
                 responseMessage
-                        .setMessage("Object " + spId + '/' + key + " insertion falied " + response.eTag());
+                        .setMessage("Object " + folderName + '/' + spId + '/' + key + " insertion falied "
+                                + response.eTag());
                 return ResponseEntity.ok().body(responseMessage);
             } else {
                 responseMessage.setSuccess(true);
                 responseMessage
-                        .setMessage(preSignedURLService(spId, spId + '/' + key).getBody().getMessage());
+                        .setMessage(
+                                preSignedURLService(spId, folderName + '/' + spId + '/' + key).getBody().getMessage());
 
                 return ResponseEntity.ok().body(responseMessage);
             }
 
         } catch (Exception e) {
             responseMessage.setSuccess(false);
-            responseMessage.setMessage("Object " + spId + '/' + key + " insertion falied " + e.getMessage());
+            responseMessage.setMessage("Object " + folderName + '/' +spId + '/' + key + " insertion falied " + e.getMessage());
             return ResponseEntity.badRequest().body(responseMessage);
         }
     }


### PR DESCRIPTION
## What does this PR do?

This PR creates a folder named ServiceProvidersImages in S3 bucket and stores all the images by making seperate folders for each and every service provider.

![image](https://github.com/BookMySport-com-Platform/Service-Provider-Place-Registration/assets/154119282/0af46f5f-0779-4822-9125-a422cd4d7bbb)

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How should this be tested?

1. Go to postman 
2. Type in the URL: http://localhost:8070/api/uploadimages
3. Give the token and url in the headers
4. In the form-data select the file and click on send.

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.